### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cleanup-pr.yml
+++ b/.github/workflows/cleanup-pr.yml
@@ -1,4 +1,7 @@
 name: cleanup caches by a branch
+permissions:
+  contents: read
+  pull-requests: read
 on:
   pull_request:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/merlinschumacher/filme-hannover/security/code-scanning/15](https://github.com/merlinschumacher/filme-hannover/security/code-scanning/15)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's functionality, it interacts with caches and pull requests, so the permissions should include `contents: read` and `pull-requests: read`. These permissions allow the workflow to fetch cache keys and interact with pull request metadata without granting unnecessary write access.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `cleanup` job. In this case, adding it at the root level is sufficient since there is only one job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
