### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cleanup-manually.yml
+++ b/.github/workflows/cleanup-manually.yml
@@ -1,8 +1,9 @@
 name: Cleanup old caches and container images
+permissions:
+  contents: write
+  packages: write
 on:
   workflow_dispatch:
-
-jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/merlinschumacher/filme-hannover/security/code-scanning/16](https://github.com/merlinschumacher/filme-hannover/security/code-scanning/16)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Based on the workflow's tasks:
1. The `gh cache delete` command likely requires `contents: write` to delete repository-related caches.
2. The `ghcr-cleanup-action` step uses the `GITHUB_TOKEN` to delete old container images, which requires `packages: write`.

We will add the following `permissions` block at the root of the workflow:
```yaml
permissions:
  contents: write
  packages: write
```

This ensures that the workflow has only the permissions it needs to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
